### PR TITLE
Added a flag bit to INV messages for getdata to denote the witness sh…

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -324,4 +324,7 @@ enum {
     MSG_WITNESS_TX,
 };
 
+const uint32_t MSG_WITNESS_FLAG = 1 << 31;
+const uint32_t MSG_TYPE_MASK = 0xffffffff >> 1; // Only one flag for now
+
 #endif // BITCOIN_PROTOCOL_H


### PR DESCRIPTION
…ould be sent.

Rather than having separate MSG_TX and MSG_WITNESS_TX we can use MSG_TX | MSG_WITNESS_FLAG

Same for MSG_BLOCK and MSG_FILTERED_BLOCK