### PR TITLE
Move virtual size test after witness malleability checks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3193,9 +3193,6 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
     // * The must be at least one output whose scriptPubKey is a single 36-byte push, the first 4 bytes of which are
     //   {0xaa, 0x21, 0xa9, 0xed}, and the following 32 bytes are SHA256(witness root, witness nonce). In case there are
     //   multiple, the last one is used.
-    if (GetVirtualBlockSize(block) > MAX_BLOCK_SIZE) {
-        return state.DoS(100, error("ContextualCheckBlock(): witness size limits failed"), REJECT_INVALID, "bad-blk-wit-length");
-    }
     if (IsWitnessEnabled(block, pindexPrev, consensusParams)) {
         int commitpos = -1;
         for (size_t o = 0; o < block.vtx[0].vout.size(); o++) {
@@ -3216,10 +3213,22 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
             if (memcmp(hashWitness.begin(), &block.vtx[0].vout[commitpos].scriptPubKey[6], 32)) {
                 return state.DoS(100, error("%s : witness merkle commitment mismatch", __func__), REJECT_INVALID, "bad-witness-merkle-match", true);
             }
+            
+            // After the coinbase witness nonce and commitment are verified,
+            // we can check if the virtual size passes (before we've checked
+            // the coinbase witness, it would be possible for the virtual
+            // size to be too large by filling up the coinbase witness,
+            // which doesn't change the block hash, so we couldn't mark
+            // the block as permanently failed).
+            // Note: we aren't checking virtual size for blocks that aren't
+            // witness enabled, but that's okay because CheckBlock still
+            // checks the block size without any witnesses.
+            if (GetVirtualBlockSize(block) > MAX_BLOCK_SIZE) {
+                return state.DoS(100, error("ContextualCheckBlock(): witness size limits failed"), REJECT_INVALID, "bad-blk-wit-length");
+            }
             return true;
         }
     }
-    // No witness data is allowed in blocks that don't commit to witness data, as this would otherwise leave room from spam.
     for (size_t i = 0; i < block.vtx.size(); i++) {
         if (!block.vtx[i].wit.IsNull()) {
             return state.DoS(100, error("%s : unexpected witness data found", __func__), REJECT_INVALID, "unexpected-witness", true);


### PR DESCRIPTION
This fixes a consensus bug: it's possible to make the coinbase witness too big, failing the virtual size test, without affecting the block hash.  Since the virtual size failure wasn't setting the `corruptionPossible` field, the block hash would be marked permanently failed.

Rather than set `corruptionPossible`, I thought it made more sense to move the check to happen after the witness data has been locked in, so that we could definitively determine if the block is bad.