### PR TITLE
Fix flag conflict with BIP112

### DIFF
--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -84,11 +84,11 @@ enum
 
     // Support segregated witness
     //
-    SCRIPT_VERIFY_WITNESS = (1U << 10),
+    SCRIPT_VERIFY_WITNESS = (1U << 11),
 
     // Making v2-v16 witness program non-standard
     //
-    SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM = (1U << 11),
+    SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM = (1U << 12),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);


### PR DESCRIPTION
Flag `(1U << 10)` has been used by BIP112 merged to bitcoin `master`.