### PR TITLE
qt: update network style name

### DIFF
--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -17,7 +17,7 @@ static const struct {
 } network_styles[] = {
     {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
     {"test", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")},
-    {"segnet", QAPP_APP_NAME_SEGNET, 30, 30, QT_TRANSLATE_NOOP("SplashScreen", "[segnet]")},
+    {"segnet4", QAPP_APP_NAME_SEGNET, 30, 30, QT_TRANSLATE_NOOP("SplashScreen", "[segnet]")},
     {"regtest", QAPP_APP_NAME_TESTNET, 160, 30, "[regtest]"}
 };
 static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);


### PR DESCRIPTION
Fixes small assertion issue when running `bitcoin-qt` with `-segnet`:
```
bitcoin-qt: qt/bitcoin.cpp:614: int main(int, char**): Assertion `!networkStyle.isNull()' failed.
```