### PR TITLE
function UpdateUncommitedBlockStructures redefine

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -455,8 +455,6 @@ bool IsWitnessEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& pa
 
 bool RewindBlockIndex(const Consensus::Params& params);
 
-void UpdateUncommitedBlockStructures(CBlock& block, const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams);
-
 /** Update uncommitted block structures (currently: only the witness nonce). This is safe for submitted blocks. */
 void UpdateUncommitedBlockStructures(CBlock& block, const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams);
 


### PR DESCRIPTION
function UpdateUncommitedBlockStructures defined twice.