### PR TITLE
policy: taproot: check prevout scriptPubKey for P2SH

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -233,7 +233,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
         }
 
         // Check P2TR standard limits
-        if (witnessversion == 1 && witnessprogram.size() == WITNESS_V1_TAPROOT_SIZE && !prevScript.IsPayToScriptHash()) {
+        if (witnessversion == 1 && witnessprogram.size() == WITNESS_V1_TAPROOT_SIZE && !prev.scriptPubKey.IsPayToScriptHash()) {
             // Taproot spend (non-P2SH-wrapped, version 1, witness program size 32; see BIP 341)
             const auto& stack = tx.vin[i].scriptWitness.stack;
             bool have_annex = stack.size() >= 2 && !stack.back().empty() && stack.back()[0] == ANNEX_TAG;


### PR DESCRIPTION
Addresses https://github.com/bitcoin/bitcoin/pull/17977#discussion_r384485907

Tests the actual previous transaction output scriptPubKey for P2SH before applying taproot standardness checks.

Also adds test for version-1-witness-in-P2SH which is NOT taproot and should not be subject to these standardness checks.

This is a hard case to test, because P2SH is correctly checked in interpreter `VerifyWitnessProgram()` and so the test case will be thrown out as non-standard for spending an unknown witness version.

To test the test, I wrote a commit https://github.com/pinheadmz/bitcoin/commit/ba1ac81d032632412d45fc9438552b7bcd2253f1 which bypasses the check in `VerifyWitnessProgram()`, allowing the v1-in-P2SH to get caught in policy `IsWitnessStandard()` which is patched by this PR.

I'm not sure if there's a better way to cover this patch because there's (at least) two standardness checks applied.